### PR TITLE
Microsoft DNS Plugin v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,41 @@ A jar will be produced in the `build/lib` folder that can be uploaded into a Mor
 
 ### Configuring
 
-Once the plugin is loaded in the environment. Microsoft DNS Becomes available in `Infrastructure -> Network -> Services`.
+Once the plugin is loaded in the environment. Microsoft DNS becomes available in `Infrastructure -> Network -> Integrations`.
 
-When adding the integration simply enter ip of the Microsoft DNS Server and the credentials with sufficient enough winrm privileges.
+Configure the Dns Integration via the CREATE MICROSOFT DNS INTEGRATION dialog.
 
+Enter a value for the Integration NAME
+
+If using a jump server or intermediate management server enter the FQDN or Address of this server in the DNS SERVER text box. If not using an intermediary server this should be the FQDN or Address of the DNS Server. In the plugin this option value is known as serviceUrl and must be reachable via WinRm.
+
+Enter the Credentials with access to the Dns Services. Choose stored Credentials or enter Username and Password. Username should be in User Principal Name format
+
+When using a jump server or Intermediate server enter the FQDN or Address of the actual DNS Server in the COMPUTER NAME text box. In the plugin this option value is known as servicePath. The plugin will access the DNS services via this computer
+
+ZONE FILTER New to v2.0 of the plugin. A comma separated list of glob style filters which can be used to specify the zones that Morpheus will import and sync. Glob style filter apply to the zone name ONLY and at a domain level. Wildcarding stops at the . (period) 
+
+The * character matches any legal Dns character [a-zA-Z0-9_-] 0 or more times 
+
+An example a filter string of
+
+*.morpheus.com, *.10.in-addr.arpa, d*.us.morpheus.com
+
+would 
+
+IMPORT test.morpheus.com, prod.morpheus.com but NOT mydomain.test.morpheus.com which has a 4th level
+IMPORT 32.10.in-addr.arpa, 33.10.in-addr.arpa but NOT 12.11.in-addr.arpa or 10.in-addr.arpa (which has 3 levels)
+IMPORT denver.us.morpheus.com and delaware.us.morpheus.com but NOT ohio.us.morpheus.com (wildcard at 4th level)
+
+
+### Validation
+
+This plugin includes improvements in error handling and validation. Connectivity and access to DNS Services is tested at the time the integration dialog is saved
+
+### Intermediary Server Support
+
+New with v2.1.0
+
+This plugin uses a technique where Powershell script blocks are executed using Invoke-Command. Using securely cached credentials stored in the user profile on the intemediate server, Invoke-Command can execute script blocks on remote computers (-ComputerName parameter) with specified Credentials (-Credential). Using this method allows for a Kerberos login from the Intermediate Server to the DNS Server overcoming NTLM impersonation restrictions. Credentials are securely cached using Windows DPAPI and can only be access by the computer and user account that cached them.
+
+No caching is required if you access the DNS Server directly

--- a/README.md
+++ b/README.md
@@ -28,17 +28,20 @@ When using a jump server or Intermediate server enter the FQDN or Address of the
 
 ZONE FILTER New to v2.0 of the plugin. A comma separated list of glob style filters which can be used to specify the zones that Morpheus will import and sync. Glob style filter apply to the zone name ONLY and at a domain level. Wildcarding stops at the . (period) 
 
-The * character matches any legal Dns character [a-zA-Z0-9_-] 0 or more times 
+The \* character matches any legal Dns character [a-zA-Z0-9_-] 0 or more times 
 
 An example a filter string of
 
+```
 *.morpheus.com, *.10.in-addr.arpa, d*.us.morpheus.com
-
+```
 would 
 
-IMPORT test.morpheus.com, prod.morpheus.com but NOT mydomain.test.morpheus.com which has a 4th level
-IMPORT 32.10.in-addr.arpa, 33.10.in-addr.arpa but NOT 12.11.in-addr.arpa or 10.in-addr.arpa (which has 3 levels)
-IMPORT denver.us.morpheus.com and delaware.us.morpheus.com but NOT ohio.us.morpheus.com (wildcard at 4th level)
+**IMPORT** test.morpheus.com, prod.morpheus.com but **NOT** mydomain.test.morpheus.com which has a 4th level
+
+**IMPORT** 32.10.in-addr.arpa, 33.10.in-addr.arpa but **NOT** 12.11.in-addr.arpa or 10.in-addr.arpa (which has 3 levels)
+
+**IMPORT** denver.us.morpheus.com and delaware.us.morpheus.com but **NOT** ohio.us.morpheus.com (wildcard at 4th level)
 
 
 ### Validation

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ org.gradle.jvmargs=-Xmx2g -Xms2g -Dfile.encoding=UTF-8
 groovyVersion=3.0.7
 spockVersion=1.3-groovy-2.5
 slf4jVersion=1.7.26
-version=2.0.0
+version=2.1.0
 


### PR DESCRIPTION
Validation improvement on the Save Integration form plus improved validation when creating DNS records. Standardised Powershell script blocks and error handling over the Morpheus core Rpc process. 

Support for using an intermediate or jump server to access DNS services. A technique for safely caching credentials on the jump server then issuing commands remotely with these credentials creates a Kerberos login from the intermediate server to the DNS Server solving lots of security restriction issues

Updated the README to give some help on setting up the integration plus some information on using the Zone Filters